### PR TITLE
Upgrade to broccoli-persistent-filter and skip _.template if the input is a .js file

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,13 +34,19 @@ function JSTFilter(inputTree, options) {
 
 JSTFilter.prototype.processString = function(string, relativePath) {
     var extensionRegex = /\.[0-9a-z\.]+$/i;
-    // var filename = relativePath.replace(extensionRegex, '');
     var templateDir = path.normalize(this.templatesRoot + path.sep);
-    var filename = relativePath.split(templateDir).reverse()[0].replace(extensionRegex, '');
-    var compiled = _.template(string, false, this.templateSettings);
+    var extension = relativePath.match(extensionRegex)[0];
+    var filename = relativePath.split(templateDir).reverse()[0].replace(extension, '');
+    var compiled = string;
+
+    // Only use _.template if the file extension does not end with .js
+    // If it does, it is assumed that the input is already a template function.
+    if (!extension.match(/\.js$/i)) {
+      compiled = _.template(string, false, this.templateSettings).source;
+    }
 
     var result = [];
-    result.push(compiled.source + ";\n")
+    result.push(compiled + ";\n")
 
     var namespaceString = null;
     var namespaceTemplateString = null;

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 var path = require('path');
-var Filter = require('broccoli-filter');
+var Filter = require('broccoli-persistent-filter');
 var jsStringEscape = require('js-string-escape');
 var _ = require('lodash');
 
 DEFAULTS = {
-    extensions: ['jst'],  
+    extensions: ['jst'],
     namespace: 'JST',
     templatesRoot: 'templates',
     templateSettings: {},
@@ -21,6 +21,7 @@ JSTFilter.prototype.targetExtension = 'js';
 
 function JSTFilter(inputTree, options) {
   if (!(this instanceof JSTFilter)) return new JSTFilter(inputTree, options);
+  Filter.call(this, inputTree, options);
   this.inputTree = inputTree;
   this.options = options || {};
   this.extensions = options.extensions || DEFAULTS.extensions;
@@ -32,9 +33,9 @@ function JSTFilter(inputTree, options) {
 }
 
 JSTFilter.prototype.processString = function(string, relativePath) {
-    var extensionRegex = /\.[0-9a-z]+$/i;
+    var extensionRegex = /\.[0-9a-z\.]+$/i;
     // var filename = relativePath.replace(extensionRegex, '');
-    var templateDir = path.normalize(this.templatesRoot + path.sep); 
+    var templateDir = path.normalize(this.templatesRoot + path.sep);
     var filename = relativePath.split(templateDir).reverse()[0].replace(extensionRegex, '');
     var compiled = _.template(string, false, this.templateSettings);
 
@@ -46,7 +47,7 @@ JSTFilter.prototype.processString = function(string, relativePath) {
     if (this.namespace !== false) {
       namespaceString = "this['" + this.namespace + "']";
       namespaceTemplateString = namespaceString + "['" + filename + "']";
-  
+
       result.unshift(namespaceTemplateString + " = ");
       result.unshift(namespaceString + " = " + namespaceString + " || {};\n");
     }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "jst"
   ],
   "dependencies": {
-    "broccoli-filter": "^0.1.6",
+    "broccoli-persistent-filter": "^1.4.3",
     "js-string-escape": "^1.0.0",
     "lodash": "^2.4.1"
   }


### PR DESCRIPTION
1. Move from broccoli-filter to broccoli-persistent-filter, partly to be compatible with latest broccolijs version.
2. If the input file extension ends with `.js`, it is assumed that the input file already contain a template function. So do not use _.template on the input file.